### PR TITLE
Update Porsche Boxster generations: Verified generational data and added Wikipedia reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # Porsche Boxster
 
+This repository contains signal set configurations for the Porsche Boxster, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Porsche Boxster.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Porsche_Boxster"
+
 generations:
   - name: "First Generation (986)"
     start_year: 1996


### PR DESCRIPTION
- Confirmed four generations match Wikipedia article structure
- First Generation (986): 1996-2004
- Second Generation (987): 2005-2012
- Third Generation (981): 2012-2016
- Fourth Generation (718/982): 2016-present
- Added Wikipedia reference to generations.yaml
- Updated README.md with standard template
